### PR TITLE
add a wc

### DIFF
--- a/bin/wc
+++ b/bin/wc
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl6
+my %*SUB-MAIN-OPTS =
+	:named-anywhere;
+
+sub tput ($term) {
+	print("\t$term");
+}
+
+my &wc = {
+	{
+		l => .lines.elems,
+		w => .words.elems,
+		c => .encode.bytes,
+		m => .codes,
+		r => .chars
+	}
+}
+	# my $name = $io.Str;
+	# my $input = $io.slurp;
+
+	# my $active-options = $options.values.grep({$_});
+
+	# tput $linecount if $options<l> or $active-options == 0;
+	# tput $wordcount if $options<w> or $active-options == 0;
+	# tput $bytecount if $options<c> or $active-options == 0;
+	# tput $codecount if $options<m>;
+	# tput $runecount if $options<r>;
+	# tput $name if $count > 1;
+	# put();
+
+sub MAIN (
+	*@files where ?*.grep({.IO.f}),
+	Bool :$l, #= lines
+	Bool :$w, #= words
+	Bool :$c, #= bytes
+	Bool :$m, #= codepoints
+	Bool :$r, #= runes
+) {
+	my $flag-count = [+] [?$l, ?$w, ?$c, ?$m, ?$r];
+	my $use-defaults = !?$flag-count;
+	my $options = [
+		:l($l || $use-defaults),
+		:w($w || $use-defaults),
+		:c($c || $use-defaults),
+		:m($m),
+		:r($r)
+	].grep(*.value).map(*.key);
+
+	my %totals;
+
+	for @files -> $file {
+		my %counts = wc($file.IO.slurp);
+
+		for %counts.kv -> $key, $value {
+			%totals<<$key>> += $value;
+		}
+
+		for $options.comb -> $key {
+			my $count = %counts<<$key>>;
+			if ($options.elems == 1) {
+				print($count);
+			} else {
+				tput($count);
+			}
+		}
+
+		if (@files.elems > 1) {
+			tput $file.Str;
+		}
+
+		put();
+	}
+
+	if (@files.elems > 1) {
+		for $options.comb -> $key {
+			my $count = %totals<<$key>>;
+			if ($options.elems == 1) {
+				print($count);
+			} else {
+				tput($count);
+			}
+		}
+		tput ｢total｣;
+		put();
+	}
+}
+
+sub USAGE {
+	put qq｢$*PROGRAM-NAME - print line, word, and byte counts for each file\n｣;
+	put ｢the options may be used to select counts to print｣;
+	put ｢always in this order: lines, words, bytes, codepoints, runes.｣ ~ "\n";
+	put $*USAGE;
+}

--- a/bin/wc
+++ b/bin/wc
@@ -2,6 +2,8 @@
 my %*SUB-MAIN-OPTS =
 	:named-anywhere;
 
+# wc actually does padding, but that's harder because
+# we'd need to know the biggest number before we start printing
 sub tab-print ($term) {
 	print("\t{$term}");
 }
@@ -28,6 +30,7 @@ sub check-goodness ($file) {
 			complain($file, ｢Is a directory｣);
 			False
 		}
+		# not readable by user
 		when !*.r {
 			complain($file, ｢Permission denied｣);
 			False
@@ -42,6 +45,7 @@ sub print-line (:$options!, :%counts!, :$name) {
 	for $options.comb -> $key {
 		my $count = %counts<<$key>>;
 
+		# wc only prints leading space is only printed if there are >1 options
 		my &print-count = $options.elems == 1
 			?? &print
 			!! &tab-print;
@@ -57,7 +61,7 @@ sub print-line (:$options!, :%counts!, :$name) {
 }
 
 sub MAIN (
-	*@files,
+	*@filenames,
 	Bool :$l, #= lines
 	Bool :$w, #= words
 	Bool :$c, #= bytes
@@ -74,12 +78,14 @@ sub MAIN (
 		:r($r)
 	].grep(*.value).map(*.key);
 
-	my %totals;
+	if (@filenames) {
+		my @files = @filenames.map(*.IO);
 
-	@files = @files.map(*.IO);
+		my %totals;
 
-	if (@files) {
+		# if we have files, count em
 		for @files -> $file {
+			# skip files that aren't countable
 			next unless check-goodness($file);
 
 			my %counts = wc(slurp($file));
@@ -95,6 +101,7 @@ sub MAIN (
 			)
 		}
 
+		# if we have more than one file, we want to see totals
 		if (@files.elems > 1) {
 			print-line(
 				:counts(%totals),
@@ -103,6 +110,7 @@ sub MAIN (
 			)
 		}
 	} else {
+		# if no files are provided, read from STDIN
 		my %counts = wc(slurp);
 
 		print-line(

--- a/bin/wc
+++ b/bin/wc
@@ -2,34 +2,62 @@
 my %*SUB-MAIN-OPTS =
 	:named-anywhere;
 
-sub tput ($term) {
-	print("\t$term");
+sub tab-print ($term) {
+	print("\t{$term}");
 }
 
 my &wc = {
-	{
-		l => .lines.elems,
-		w => .words.elems,
-		c => .encode.bytes,
-		m => .codes,
-		r => .chars
+	l => .lines.elems,
+	w => .words.elems,
+	c => .encode.bytes,
+	m => .codes,
+	r => .chars
+}
+
+sub complain ($file, $complaint) {
+	$*ERR.put: "$*PROGRAM-NAME: $file: $complaint";
+}
+
+sub check-goodness ($file) {
+	given $file {
+		when !*.e {
+			complain($file, ｢No such file or directory｣);
+			False
+		}
+		when .d {
+			complain($file, ｢Is a directory｣);
+			False
+		}
+		when !*.r {
+			complain($file, ｢Permission denied｣);
+			False
+		}
+		default {
+			True
+		}
 	}
 }
-	# my $name = $io.Str;
-	# my $input = $io.slurp;
 
-	# my $active-options = $options.values.grep({$_});
+sub print-line (:$options!, :%counts!, :$name) {
+	for $options.comb -> $key {
+		my $count = %counts<<$key>>;
 
-	# tput $linecount if $options<l> or $active-options == 0;
-	# tput $wordcount if $options<w> or $active-options == 0;
-	# tput $bytecount if $options<c> or $active-options == 0;
-	# tput $codecount if $options<m>;
-	# tput $runecount if $options<r>;
-	# tput $name if $count > 1;
-	# put();
+		if ($count ~~ Int && $options.elems == 1) {
+			print($count) if $count;
+		} else {
+			tab-print($count) if $count;
+		}
+	}
+
+	if $name {
+		tab-print $name
+	};
+
+	put();
+}
 
 sub MAIN (
-	*@files where ?*.grep({.IO.f}),
+	*@files,
 	Bool :$l, #= lines
 	Bool :$w, #= words
 	Bool :$c, #= bytes
@@ -48,40 +76,39 @@ sub MAIN (
 
 	my %totals;
 
-	for @files -> $file {
-		my %counts = wc($file.IO.slurp);
+	@files = @files.map(*.IO);
 
-		for %counts.kv -> $key, $value {
-			%totals<<$key>> += $value;
-		}
+	if (@files) {
+		for @files -> $file {
+			next unless check-goodness($file);
 
-		for $options.comb -> $key {
-			my $count = %counts<<$key>>;
-			if ($options.elems == 1) {
-				print($count);
-			} else {
-				tput($count);
+			my %counts = wc(slurp($file));
+
+			for %counts.kv -> $key, $value {
+				%totals<<$key>> += $value;
 			}
+
+			print-line(
+				:counts(%counts),
+				:options($options),
+				:name($file.Str)
+			)
 		}
 
 		if (@files.elems > 1) {
-			tput $file.Str;
+			print-line(
+				:counts(%totals),
+				:options($options),
+				:name(｢total｣)
+			)
 		}
+	} else {
+		my %counts = wc(slurp);
 
-		put();
-	}
-
-	if (@files.elems > 1) {
-		for $options.comb -> $key {
-			my $count = %totals<<$key>>;
-			if ($options.elems == 1) {
-				print($count);
-			} else {
-				tput($count);
-			}
-		}
-		tput ｢total｣;
-		put();
+		print-line(
+			:counts(%counts),
+			:options($options)
+		)
 	}
 }
 

--- a/bin/wc
+++ b/bin/wc
@@ -42,11 +42,11 @@ sub print-line (:$options!, :%counts!, :$name) {
 	for $options.comb -> $key {
 		my $count = %counts<<$key>>;
 
-		if ($count ~~ Int && $options.elems == 1) {
-			print($count) if $count;
-		} else {
-			tab-print($count) if $count;
-		}
+		my &print-count = $options.elems == 1
+			?? &print
+			!! &tab-print;
+
+		print-count($count) if $count ~~ Int;
 	}
 
 	if $name {


### PR DESCRIPTION
one noteable difference from `wc` is that i don't print `0 0 0` for directories 

here's a document:

---

# wc(1)

`wc` counts newlines, words, runes and bytes in the named files, and a total if more than one `file` is specified.
If `file` is not provided, or `file` is `-`, `wc` counts `stdin`.
A word is a maximal string of characters delimited by whitespace.
If the optional argument is present, the specified counts are selected by letters:

| count  | letter |
| -- | -- |
| line  | `l` |
| word  | `w` |
| rune  | `r` or `m`  |
| byte | `c` |

Otherwise, lines, words and bytes (`-l -w -c`) are reported.

---

closes #104
